### PR TITLE
travis: Add a basic build description for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: xenial   # required for Python >= 3.7
+language: python
+python:
+  - 3.7
+
+install:
+  - npm install
+  - pipenv install
+
+script:
+  - pipenv run ./manage.py migrate
+  - pipenv run ./manage.py loaddata sites


### PR DESCRIPTION
This just runs the setup for now, there is no testing of the
running service.

- Specify Python 3.7.
- Specify Ubuntu Xenial (16.04) which is required for Python 3.7.
- The above image includes a new enough pipenv to use directly.
  This is part of travis' custom Python package, not the one
  from the distro.
- Use the default npm of the image.

To make use of this file, code must be hosted on github and
the specific repository added to travis. To do this, visit
travis-ci.org, log in with github credentials,  and authorize
travis to access your github repositories.

Synchonize your account and visit the config for the specific
repository under https://travis-ci.org/account/repositories
and enable travis for that project.

After that travis will run the build commands specified in
this file on every new commit and post feedback on pull requests.
This helps assure that code changes haven't broken something
fundamental to the application.